### PR TITLE
Support relay state

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Included features:
 - Tagging of permission sets
 
 ## Usage
-**IMPORTANT:** The `master` branch is used in source just as an example. In your code, do not pin to master because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`).
+**IMPORTANT:** The `main` branch is used in source just as an example. In your code, do not pin to master because there may be breaking changes between releases. Instead pin to the release tag (e.g. `?ref=tags/x.y.z`).
 
 Include this repository as a module in your existing terraform code. **Additional examples** can be found in the [examples directory](./examples/)
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -23,8 +23,8 @@ locals {
 ## Permission Sets and Assignments
 ###########################################################################
 module "EngineeringPowerUser" {
-  source = "../"
-  tags = local.default_tags
+  source                     = "../"
+  tags                       = local.default_tags
   inline_policy              = file("permission-sets/EngineeringPowerUser.json")
   permission_set_name        = "EngineeringPowerUser"
   permission_set_description = "12 hour Power User Access"
@@ -65,8 +65,8 @@ module "SuperAdmin1Hour" {
 }
 
 module "InlineAndManaged" {
-  source = "../"
-  tags = local.default_tags
+  source        = "../"
+  tags          = local.default_tags
   inline_policy = file("permission-sets/inline.json")
   managed_policies = [
     "arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess"
@@ -84,8 +84,8 @@ module "InlineAndManaged" {
 }
 
 module "SingleUser" {
-  source = "../"
-  tags = local.default_tags
+  source        = "../"
+  tags          = local.default_tags
   inline_policy = file("permission-sets/inline.json")
   managed_policies = [
     "arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess"
@@ -104,7 +104,7 @@ module "SingleUser" {
 
 module "UserAndGroup" {
   source = "../"
-  tags = local.default_tags
+  tags   = local.default_tags
   managed_policies = [
     "arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess"
   ]
@@ -116,6 +116,25 @@ module "UserAndGroup" {
   ]
   principal_group_id = [
     "InlineAndManaged"
+  ]
+  account_ids = [
+    "354990512722"
+  ]
+}
+
+module "RelayState" {
+  source        = "../"
+  tags          = local.default_tags
+  inline_policy = file("permission-sets/inline.json")
+  managed_policies = [
+    "arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess"
+  ]
+  permission_set_name        = "RelayState"
+  permission_set_description = "1 hour that redirects user to specific page"
+  session_duration           = "PT1H"
+  relay_state                = "https://s3.console.aws.amazon.com/s3/home?region=us-east-1#"
+  principal_user_id = [
+    "mmartin"
   ]
   account_ids = [
     "354990512722"

--- a/main.tf
+++ b/main.tf
@@ -26,10 +26,10 @@ locals {
 data "aws_ssoadmin_instances" "organization_management_account" {}
 
 resource "aws_ssoadmin_permission_set" "default" {
-  name         = var.permission_set_name
-  description  = var.permission_set_description
-  instance_arn = tolist(data.aws_ssoadmin_instances.organization_management_account.arns)[0]
-  # relay_state =
+  name             = var.permission_set_name
+  description      = var.permission_set_description
+  instance_arn     = tolist(data.aws_ssoadmin_instances.organization_management_account.arns)[0]
+  relay_state      = var.relay_state
   session_duration = var.session_duration
   tags             = module.label.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -51,5 +51,5 @@ variable "tags" {
 variable "relay_state" {
   type        = string
   description = "The relay state URL used to redirect users within the application during the federation authentication process."
-  default     = ""
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,3 +47,9 @@ variable "tags" {
   description = "Resource tags"
   type        = map(string)
 }
+
+variable "relay_state" {
+  type        = string
+  description = "The relay state URL used to redirect users within the application during the federation authentication process."
+  default     = ""
+}


### PR DESCRIPTION
There comes a time where you need to support a feature that you never think you'd need. Well here it is! I ended up wanting users that only have access to a certain s3 bucket and folder combination be forwarded directly to the s3 aws console page they need.